### PR TITLE
GH-36: Implement owned game list page

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,7 +6,7 @@ const nextConfig = {
             {
                 protocol: 'https',
                 hostname: 'steamcdn-a.akamaihd.net',
-                pathname: '/steamcommunity/**',
+                pathname: '/steam*/**',
             },
         ],
     },

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -1,0 +1,30 @@
+import {Game} from "@/entities/Game";
+
+export async function GET(request: Request) {
+    const {searchParams} = new URL(request.url);
+    const url = `https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?${searchParams.toString()}&include_appinfo=true`
+    const resultFromSteam = await fetch(url, {
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+    });
+    const steamJson: Record<string, unknown> = (await resultFromSteam.json()).response;
+
+    const responseData = {
+      gameCount: steamJson.game_count,
+        games: (steamJson.games as Array<Record<string, unknown>>|| []).map((game: Record<string, unknown>) => {
+            const mappedGame: Game = {
+                appId: game.appid?.toString() || '',
+                title: game.name?.toString() || '',
+                playTime: Number.parseInt(game?.playtime_forever?.toString() || '0'),
+                cover_img_url: `https://steamcdn-a.akamaihd.net/steam/apps/${game.appid}/library_600x900_2x.jpg`,
+                icon_img_url: `https://media.steampowered.com/steamcommunity/public/images/apps/${game.appid}/${game.img_icon_url}.jpg`,
+            }
+
+            return mappedGame;
+        })
+    };
+
+    return Response.json(responseData);
+}

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -1,0 +1,48 @@
+'use client'
+import React, {useEffect, useState} from "react";
+import {CircularProgress} from "@mui/material";
+import {Game} from "@/entities/Game";
+import getGames from "@/services/getGames";
+import Image from "next/image";
+import Link from "next/link";
+import {useRouter} from "next/navigation";
+
+function GameCard({game}: { game: Game }): React.ReactElement {
+    return (
+        <Link href={"/kanban/" + game.appId}>
+            <div className={"flex flex-col w-60"}>
+                <div className={"relative w-60 h-96 bg-amber-800 rounded-sm"}>
+                    <Image fill={true}
+                           title={game.title}
+                           src={game.cover_img_url}
+                           className={"rounded-sm border-none"}
+                           alt={""}/>
+                </div>
+                <div className={"overflow-auto text-center"}>{game.title}</div>
+            </div>
+        </Link>
+    )
+}
+
+export default function GameListPage() {
+    const [games, setGames] = useState<Array<Game> | null>(null)
+    const router = useRouter();
+
+    useEffect(() => {
+        getGames().then(setGames).catch(() => router.push("/"))
+    }, [router]);
+
+    if (games == null) {
+        return (
+            <div className="w-full h-full flex flex-col">
+                <CircularProgress size="10rem" className="m-auto"/>
+            </div>
+        )
+    }
+
+    return (
+        <div className={"flex flex-row flex-wrap gap-10 justify-around"}>
+            {games.map(game => <GameCard key={game.appId} game={game}/>)}
+        </div>
+    )
+}

--- a/src/app/kanban/[appId]/page.tsx
+++ b/src/app/kanban/[appId]/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+import getAchievementData from "@/services/getAchievementData";
+import {useEffect, useState} from "react";
+import {CircularProgress} from "@mui/material";
+import KanbanBoard from "@/components/kanban/kanban-board/kaban-board";
+import {Achievement} from "@/entities/Achievement";
+import {useRouter} from "next/navigation";
+
+export default function KanbanBoardPage(params: {params: { appId: string}}) {
+    const [achievements, setAchievements] = useState<Array<Achievement> | null>(null)
+    const router = useRouter();
+
+    useEffect(() => {
+        getAchievementData({appId: params.params.appId}).then((resp) => {
+            setAchievements(resp);
+        }).catch(() => router.push("/"))
+    }, [params, router]);
+
+    if (achievements == null) {
+        return (
+            <div className="w-full h-full flex flex-col">
+                <CircularProgress size="10rem" className="m-auto"/>
+            </div>
+        )
+    }
+
+    return <KanbanBoard achievements={achievements} gameId={params.params.appId} />
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,26 +1,84 @@
 'use client'
-import getAchievementData from "@/services/getAchievementData";
-import {useEffect, useState} from "react";
-import {Achievement} from "@/entities/Achievement";
-import {CircularProgress} from "@mui/material";
-import KanbanBoard from "@/components/kanban/kanban-board/kaban-board";
+
+import {getSteamConfig} from "@/services/getSteamConfig";
+import {
+    Alert,
+    Button,
+    CircularProgress,
+    Link as MatLink,
+    List,
+    ListItem,
+    ListItemAvatar,
+    ListItemText
+} from "@mui/material";
+import Link from "next/link";
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import VpnKeyIcon from '@mui/icons-material/VpnKey';
+import {useRouter} from "next/navigation";
+import React, {useEffect, useState} from "react";
 
 export default function Home() {
-  const [achievements, setAchievements] = useState<Array<Achievement> | null>(null)
+    const [appConfigured, setAppConfigured] = useState<boolean | null>(null);
 
-  useEffect(() => {
-    getAchievementData().then((resp) => {
-      setAchievements(resp);
-    })
-  }, []);
+    useEffect(() => {
+        const config = getSteamConfig();
+        if (config.apiKey && config.userId) {
+            setAppConfigured(true);
+        }
+    }, []);
 
-  if (achievements == null) {
+    const router = useRouter();
+
+    const linkToGamesPage = <Link href={"/games"}><Button variant={"contained"} color={"primary"}>View game
+        list</Button></Link>
+
+    const appNeedsKeyAlert = <Alert severity={"info"}>
+        <div>
+            Please add your Steam API key & your steam ID to the application local storage to use the app. (Press
+            F12 {">"} app
+            tab {">"} local storage)
+        </div>
+        <List>
+            <ListItem>
+                <ListItemAvatar>
+                    <AccountCircleIcon/>
+                </ListItemAvatar>
+                <ListItemText>
+                    You can get your steam account ID in your <MatLink href={"https://store.steampowered.com/account/"}
+                                                                       target={"_blank"}>steam account details</MatLink>.
+                </ListItemText>
+            </ListItem>
+            <ListItem>
+                <ListItemAvatar>
+                    <VpnKeyIcon/>
+                </ListItemAvatar>
+                <ListItemText>
+                    You can get your steam API key in the <MatLink href={"https://steamcommunity.com/dev/apikey"}
+                                                                   target={"_blank"}>steam developer portal</MatLink>.
+                </ListItemText>
+            </ListItem>
+            <ListItem>
+                <Button variant={"contained"} color={"primary"} onClick={() => router.refresh()}>Confirm keys added</Button>
+            </ListItem>
+        </List>
+    </Alert>
+
+    const appIsReadyAlert = <Alert severity={"success"}>App is ready!</Alert>
+
+    const appReadySection = appConfigured == null ?
+        <CircularProgress size="2rem" className="m-auto"/> : (
+            <>
+                {appConfigured ? appIsReadyAlert : appNeedsKeyAlert}
+                {appConfigured ? linkToGamesPage : null}
+            </>
+        )
+
     return (
-        <div className="w-full h-full flex flex-col">
-          <CircularProgress size="10rem" className="m-auto"/>
+        <div className="w-full h-full flex flex-col items-center justify-around">
+            <div className={"flex flex-col gap-4"}>
+                <h1 className={"text-4xl font-bold"}>Welcome to Achievemint!</h1>
+                {appReadySection}
+            </div>
         </div>
     )
-  }
-
-  return <KanbanBoard achievements={achievements} />
 }

--- a/src/components/kanban/kanban-board/kaban-board.tsx
+++ b/src/components/kanban/kanban-board/kaban-board.tsx
@@ -12,12 +12,12 @@ enum SectionKey {
     LOCKED = "locked", IN_PROGRESS = "inprogress", UNLOCKED = "unlocked"
 }
 
-export default function KanbanBoard({achievements}: { achievements: Achievement[] }): React.ReactElement {
+export default function KanbanBoard({achievements, gameId}: { achievements: Achievement[], gameId: string }): React.ReactElement {
     const locked: Array<Achievement> = []
     const unlocked: Array<Achievement> = []
     const inProgressAchievements: Array<Achievement> = []
 
-    const {inProgress, removeFromInProgress, addToInProgress} = useInProgress();
+    const {inProgress, removeFromInProgress, addToInProgress} = useInProgress(gameId);
     const [activeAchievementDrag, setActiveAchievementDrag] = useState<Achievement | null>(null);
 
     achievements.forEach((achievement) => {

--- a/src/entities/Game.ts
+++ b/src/entities/Game.ts
@@ -1,0 +1,7 @@
+export interface Game {
+    appId: string;
+    title: string;
+    playTime: number;
+    icon_img_url: string;
+    cover_img_url: string;
+}

--- a/src/entities/SteamConfig.ts
+++ b/src/entities/SteamConfig.ts
@@ -1,5 +1,4 @@
 export interface SteamConfig {
-    gameId: string;
     userId: string;
     apiKey: string;
 }

--- a/src/hooks/useInProgress.ts
+++ b/src/hooks/useInProgress.ts
@@ -1,4 +1,3 @@
-import {getSteamConfig} from "@/services/getSteamConfig";
 import {useState} from "react";
 import {useLocalStorage} from "./useLocalStorage";
 
@@ -9,13 +8,12 @@ interface InProgressHook {
 }
 
 
-export function useInProgress(): InProgressHook {
-    const steamInfo = getSteamConfig();
-    if (!steamInfo?.gameId) {
-        throw new Error("Steam Info not found");
+export function useInProgress(gameId: string): InProgressHook {
+    if (!gameId) {
+        throw new Error("I need a game id!");
     }
 
-    const {getValue, setValue} = useLocalStorage(`kanban_${steamInfo.gameId}`);
+    const {getValue, setValue} = useLocalStorage(`kanban_${gameId}`);
 
     const [inProgressArray, _setInProgress] = useState<Array<string>>(JSON.parse(getValue() || '[]'));
 

--- a/src/services/getAchievementData.ts
+++ b/src/services/getAchievementData.ts
@@ -2,11 +2,11 @@ import {Achievement} from "@/entities/Achievement";
 import {SteamConfig} from "@/entities/SteamConfig";
 import {getSteamConfig} from "@/services/getSteamConfig";
 
-export default async function getAchievementData(): Promise<Array<Achievement>> {
+export default async function getAchievementData(args: {appId: string}): Promise<Array<Achievement>> {
     const query: SteamConfig = getSteamConfig();
-    const resp = await (await fetch(`/api/achievementData?appid=${query.gameId}&steamid=${query.userId}&key=${query.apiKey}&l=en_us`)).json()
+    const resp = await (await fetch(`/api/achievementData?appid=${args.appId}&steamid=${query.userId}&key=${query.apiKey}&l=en_us`)).json()
 
-    return resp.response1.playerstats.achievements.map((entry: {
+    return (resp.response1.playerstats.achievements || []).map((entry: {
         apiname: string,
         name: string,
         description: string,

--- a/src/services/getGames.ts
+++ b/src/services/getGames.ts
@@ -1,0 +1,8 @@
+import {Game} from "@/entities/Game";
+import {getSteamConfig} from "@/services/getSteamConfig";
+
+export default async function getGames(): Promise<Array<Game>> {
+    const steamInfo = getSteamConfig();
+    const response = await fetch(`/api/games?&steamid=${steamInfo.userId}&key=${steamInfo.apiKey}`);
+    return (await response.json()).games;
+}

--- a/src/services/getSteamConfig.ts
+++ b/src/services/getSteamConfig.ts
@@ -5,7 +5,6 @@ import {useLocalStorage} from "@/hooks/useLocalStorage";
 
 export function getSteamConfig(): SteamConfig {
     const retVal: SteamConfig = {
-        gameId: "placeholder",
         userId: "placeholder",
         apiKey: "placeholder"
     }


### PR DESCRIPTION
- Added home page
- Added how-to set up app
- Added redirects if the app is not configured
- home page indicates if app is ready or not
- Added games list page
- clicking on a game on the list page


![image](https://github.com/user-attachments/assets/292d8592-478f-43c3-a806-b96909428e20)

[Screencast from 2024-10-27 16-25-34.webm](https://github.com/user-attachments/assets/ae61d897-e32d-4213-9a3f-fdf80e0c2753)

![image](https://github.com/user-attachments/assets/06e39739-15df-4371-a5a9-3424a5f6fa8f)

[Screencast from 2024-10-27 16-27-11.webm](https://github.com/user-attachments/assets/8bfa7401-efe4-41ca-9812-5a735f84c859)
